### PR TITLE
.travis.yml: Update gitignore deploy exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ notifications:
 
 # Remove /dist/ from .gitignore
 before_deploy:
-  - sed -i '/\/dist\//d' ./.gitignore
+  - sed -i '/dist\//d' ./.gitignore
 
 deploy:
   provider: pages


### PR DESCRIPTION
The .gitignore rule was changed from /dist/ to dist/,
but the deploy exception was not updated.

Fixes https://github.com/coala/gh-board/issues/49