### PR TITLE
Set pre-fetch time limit for pull requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8626,6 +8626,11 @@
       "integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA==",
       "dev": true
     },
+    "netlify-env": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/netlify-env/-/netlify-env-0.0.4.tgz",
+      "integrity": "sha512-Vo3MbBQf9qBybhjKGc66xlj2zqgpllarQp3XOk/Gn1D4YHVhVqglIEX858JeRQkEXwRn9dVJ32AG+LI/DcouKQ=="
+    },
     "nice-try": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "memdown": "^1.1.2",
     "mermaid": "^7.0.0",
     "moment": "2.18.1",
+    "netlify-env": "0.0.4",
     "octicons": "^6.0.0",
     "octokat": "^0.7.0",
     "prop-types": "^15.6.1",


### PR DESCRIPTION
Detect Netlify deploy for pull requests
and use time limit to speed up deploy.

Closes https://github.com/coala/gh-board/issues/57