### PR TITLE
gh-board-gitignore.jj2: Add `src/lib/columns.js`

### DIFF
--- a/.moban.dt/gh-board-gitignore.jj2
+++ b/.moban.dt/gh-board-gitignore.jj2
@@ -7,5 +7,6 @@
 *.patch
 *.orig
 *.diff
+!*/src/lib/columns.js
 
 {% endblock %}


### PR DESCRIPTION
Added an exception in `.moban.dt/gh-board-gitignore.jj2`

Closes #50