### PR TITLE
login-modal.jsx: Add exception for default api url

### DIFF
--- a/src/components/login-modal.jsx
+++ b/src/components/login-modal.jsx
@@ -41,6 +41,7 @@ class Login extends Component {
       let hostname = document.location.hostname;
       let tld = hostname.split('.').slice(-2).join('.');
       if (tld == 'github.io') return null;
+      if (tld == 'netlify.com') return null;
       if (tld == 'localhost') return null;
       return 'https://' + hostname + '/api/v3';
 


### PR DESCRIPTION
Set default api url to null if host is Netlify

Closes https://github.com/coala/gh-board/issues/71