### PR TITLE
README.md: Fix minor table of contents inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Why waste time and money paying for a Ticket Tracker when you already work in Gi
   - [Moving Cards](#moving-cards)
   - [Task Lists](#task-lists)
   - [CI Status and Merge Conflict](#ci-status-and-merge-conflict)
+  - [Burnup Chart](#burnup-chart)
   - [Issue Images](#issue-images)
   - [Pull Request to non-default branch](#pull-request-to-non-default-branch)
   - [Batch-Edit Labels in Multiple Repositories](#batch-edit-labels-in-multiple-repositories)
-  - [Burnup Chart](#burnup-chart)
 - [Examples](#examples)
 - [Development](#development)
   - [How Does it Work?](#how-does-it-work)
@@ -112,7 +112,7 @@ It also skips when nothing was opened or closed that day/month/year (useful to s
 ![burnup-chart](https://cloud.githubusercontent.com/assets/253202/14406693/5e05c870-fe7d-11e5-9564-ecddb08ebe0d.png)
 
 
-# Issue Image
+### Issue Images
 
 If an Issue or Pull Request contains an image then it will be shown in the Issue
 


### PR DESCRIPTION
Move the Burnup Chart entry to correct place in table of contents.
Rename Issue Image --> Issue Images to fix link in contents link.
Change the Issue Images heading to h3 to fit match other headings.

Closes: https://github.com/coala/gh-board/issues/55