### PR TITLE
Add logos to navbar and dashboard

### DIFF
--- a/src/components/app/nav.jsx
+++ b/src/components/app/nav.jsx
@@ -173,6 +173,7 @@ class AppNav extends Component {
           <span className='repo-owner'>{repoOwner}</span>
           {'/'}
           {repoNameItems}
+          <img className='avatar-image' src={'https://github.com/' + repoOwner + '.png'} alt='repo-owner'/>
         </li>
       );
     }

--- a/src/components/dashboard.jsx
+++ b/src/components/dashboard.jsx
@@ -187,6 +187,7 @@ class RepoGroup extends Component {
     }
     const header = (
       <span className='org-header'>
+        <img className='org-logo' src={'https://github.com/' + repoOwner + '.png'} alt='repo-owner'/>
         {orgIcon}
         {' '}
         {repoOwner}

--- a/style/app.less
+++ b/style/app.less
@@ -55,7 +55,7 @@ body { background-color: #ddd; }
 
   .badge { margin-right: .3rem; }
 
-  .avatar-image {
+  .avatar-image, .org-logo {
     display: inline-block;
     overflow: hidden;
     line-height: 1;
@@ -63,6 +63,9 @@ body { background-color: #ddd; }
     width: 2.5rem;
     height: 2.5rem;
     border-radius: 1.25rem;
+  }
+  .org-logo {
+      margin-right: 5px;
   }
 
   .bottombar-nav { opacity: .9; }


### PR DESCRIPTION
This update shows the organisation or owner logo in kanban board navbar
and repositories on dashboard.

Closes https://github.com/coala/gh-board/issues/100