### PR TITLE
Include /src/lib directory in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -456,3 +456,6 @@ cscope.po.out
 *.patch
 *.orig
 *.diff
+
+# Explicitly include all source files in lib
+!/src/lib/*

--- a/.moban.dt/gh-board-gitignore.jj2
+++ b/.moban.dt/gh-board-gitignore.jj2
@@ -8,4 +8,9 @@
 *.orig
 *.diff
 
+<<<<<<< HEAD
+!/src/lib/columns.js
+=======
+>>>>>>> 537bb9c... Include /src/lib directory in git
+
 {% endblock %}


### PR DESCRIPTION
Adds rule to .gitignore and .moban.dt/gh-board-gitignore.jj2
to explicitly include the /src/lib folder in all git commits.

Closes https://github.com/coala/gh-board/issues/50