### PR TITLE
app.less: Remove unused .game-modal

### DIFF
--- a/style/app.less
+++ b/style/app.less
@@ -290,17 +290,6 @@ i.icon-spin {
 }
 
 
-
-.game-modal {
-  .modal-content {
-    width: 720px;
-    .game-wrapper {
-      width: 690px;
-      height: 534px;
-    }
-  }
-}
-
 // react-dnd now requires DragSource and DropTarget elements to be simple Components
 // so I had to insert a wrapper div around ListGroupItem
 // .list-group > .-drag-source + .-drag-source { border-top: 1px solid #eee; }


### PR DESCRIPTION
Removed styles for .game-modal that were not needed, as specified in issue #136.

Closes https://github.com/coala/gh-board/issues/136

Please let me know if I've done anything wrong. Will amend commit as needed.