### PR TITLE
issue-store.js: Resolve promise directly at first time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,9 @@ typings/
 # Serverless directories
 .serverless
 
+# FuseBox cache
+.fusebox/
+
 # VirtualEnv rules
 # Virtualenv
 # http://iamzed.com/2009/05/07/a-primer-on-virtualenv/


### PR DESCRIPTION
This resolves _fetchAllIssues promise directly before polling starts.
The benefit is that users don't need to wait until they see pre-fetched cards.

Closes https://github.com/coala/gh-board/issues/173