### PR TITLE
Handle invalid tokens on login

### DIFF
--- a/src/components/app/nav.jsx
+++ b/src/components/app/nav.jsx
@@ -63,7 +63,9 @@ class AppNav extends Component {
       // }
       this.setState({info});
     }).catch(() => {
-      this.setState({info: null});
+      alert('Github token is invalid.');
+      this.onSignOut();
+      this.setState({info: null, showModal: true});
     });
   };
 


### PR DESCRIPTION
When the token is invalid, sign-out the user and show login-modal again.
Fixes #72 