### PR TITLE
router.jsx: Remove unused state & replace parameter

### DIFF
--- a/src/router.jsx
+++ b/src/router.jsx
@@ -27,7 +27,7 @@ import {parseRoute, buildRoute} from './route-utils';
 const routes = [
   // Redirect from `/dashboard` to `/`
   { path: '/dashboard',
-    onEnter: (state, replace) => history.push('/')
+    onEnter: () => history.push('/')
   },
   { path: '/',
     component: App,


### PR DESCRIPTION
The two arguments `state` and `replace` in `onEnter` are not required.
In the route when `/dashboard` matches, it is directed to `/` using
browserHistory.push().

Closes https://github.com/coala/gh-board/issues/137